### PR TITLE
🐛 Bug fix for Minified React error #418 in DevTools

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,16 +9,12 @@ const Header = () => {
   return (
     <header className="flex items-center justify-between py-10">
       <div>
-        <Link href="/" aria-label={siteMetadata.headerTitle}>
-          <div className="flex items-center justify-between">
-            {typeof siteMetadata.headerTitle === 'string' ? (
-              <div className="hidden h-6 text-3xl font-semibold sm:block">
-                <a>F A</a>
-              </div>
-            ) : (
-              siteMetadata.headerTitle
-            )}
-          </div>
+        <Link
+          className="hidden h-6 text-3xl font-semibold sm:block"
+          href="/"
+          aria-label={siteMetadata.headerTitle}
+        >
+          F A
         </Link>
       </div>
       <div className="flex items-center space-x-4 pt-3 leading-5 sm:space-x-6">


### PR DESCRIPTION
Fixed the Minified React error #418 by removing unnecessary code and just using the static text for the `<Link>` component. Having an `<a>` tag inside of the `<div>` and ternary operation caused console errors in the dev tools. 