### PR TITLE
📝 Blog Revisions: Made it less formal

### DIFF
--- a/data/blog/231221-hello-world.mdx
+++ b/data/blog/231221-hello-world.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hello World! 👋
 date: '2023-12-21'
-lastmod: '2023-12-27'
+lastmod: '2023-01-11'
 tags: ['technology', 'fitness', 'personal']
 images: ['/static/images/2301/2301-banner-image.webp']
 draft: false
@@ -9,8 +9,6 @@ summary: 'A quick intro on why I created my own website and decided to blog.'
 ---
 
 ![My Picture](/static/images/2301/2301-banner-image.webp)
-
-# Introduction 
 
 Welcome 👋 and thank you for visiting my website! 
 It's still in its early stages 🚧 and there's not much content nor interactions but expect more in the coming weeks. 

--- a/data/blog/240108-posthog-over-google-analytics.mdx
+++ b/data/blog/240108-posthog-over-google-analytics.mdx
@@ -10,9 +10,7 @@ summary: "Reasons why I chose an open source analytics tool over a trillion doll
 
 ![Post Banner](/static/images/2401/2401-08-banner.webp)
 
-# Introduction
-
-Greetings, fellow readers! 🚀 On December 21, 2023, I launched the first version of my site, and you can check out the inaugural post [here](https://francisaguilar.co/blog/231221-hello-world).
+Greetings! 🚀 On December 21, 2023, I launched the first version of my site, and you can check out the inaugural post [here](https://francisaguilar.co/blog/231221-hello-world).
 A few days later, I realized I wanted to add some analytics to my site to better track how it performs and be more data-driven when it comes to making changes.
 Moreover, I wanted to see how good my site's SEO is. Almost all of my past projects including the startup I cofounded used Google Analytics (GA). 
 GA is reliable when it comes to tracking ad efficiency, funnels, retention, tracking monetization analytics, and Google integration.
@@ -151,7 +149,7 @@ Although, this is possible in PostHog, creating custom insights to copy GA4's re
 
 Lastly, nothing beats GA when it comes to seamless integrations within the Google ecosystem. Apps like Looker Stuidio, Ad Sense, Search Console, and BigQuery offer immedediate compatibility.
 
-# Conclusion
+# My Takeaway
 
 Overall, I will be using PostHog for my future hobby projects and custom developments unless explicitly specified that it requires Google Analytics. 
 The features that it offers cover almost 95% of the use cases that I handle while having a cheap price tag. 


### PR DESCRIPTION
Removed `Introduction` section & renamed `Conclusion` section to `My Takeaway`. The reason behind this change is that a friend of mine, Bats suggested that it shouldn't be too uptight. Having seeing an Introduction & Conclusion made him feel like he was reading a research paper instead of a blog.